### PR TITLE
Changed bootstrap css import of labels and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Add following lines to Gemfile:
 
-    gem "bootstrap-sass", "~> 2.0"
+    gem "bootstrap-sass", "~> 2.0.3"
     gem "formtastic", "~> 2.1"
     gem "formtastic-plus-bootstrap"
 

--- a/formtastic-plus-bootstrap.gemspec
+++ b/formtastic-plus-bootstrap.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "railties", ">= 3.1.0"
   s.add_runtime_dependency "sass-rails"
-  s.add_runtime_dependency "bootstrap-sass", "~> 2.0"
+  s.add_runtime_dependency "bootstrap-sass", "~> 2.0.3"
   s.add_runtime_dependency "formtastic", "~> 2.2"
 
   s.files = Dir["lib/**/*"] + ["README.md", "LICENSE"]

--- a/lib/assets/stylesheets/bootstrap-without-forms.css.scss
+++ b/lib/assets/stylesheets/bootstrap-without-forms.css.scss
@@ -42,8 +42,7 @@
 
 // Components: Misc
 @import "bootstrap/thumbnails";
-@import "bootstrap/labels";
-@import "bootstrap/badges";
+@import "bootstrap/labels-badges";
 @import "bootstrap/progress-bars";
 @import "bootstrap/accordion";
 @import "bootstrap/carousel";


### PR DESCRIPTION
Changed bootstrap css import of labels and badges to "labels-badges" to support Bootstrap 2.0.3
