### PR TITLE
Add date/time picker class styles

### DIFF
--- a/lib/assets/stylesheets/formtastic-plus-bootstrap/inputs/_stringish.scss
+++ b/lib/assets/stylesheets/formtastic-plus-bootstrap/inputs/_stringish.scss
@@ -5,7 +5,11 @@
   input[type='email'],
   input[type='url'],
   input[type='tel'],
-  input[type='search'] {
+  input[type='search'],
+  input[type='date'],
+  input[type='time'],
+  input[type='datetime'],
+  input[type='datetime-local'] {
     @include text-input();
   }
 }


### PR DESCRIPTION
Formtastic includes DatePickerInput, TimePickerInput, and DateTimePickerInput, which are useful but aren't styled. This commit adds those types.

e.g.: http://rdoc.info/github/justinfrench/formtastic/Formtastic/Inputs/DatetimePickerInput
