### PR TITLE
Fix, bootstrap responsive now is only loaded when required

### DIFF
--- a/lib/assets/stylesheets/bootstrap-without-forms.css.scss
+++ b/lib/assets/stylesheets/bootstrap-without-forms.css.scss
@@ -51,5 +51,3 @@
 
 // Utility classes
 @import "bootstrap/utilities"; // Has to be last to override when necessary
-
-@import "bootstrap-responsive";

--- a/lib/assets/stylesheets/formtastic-plus-bootstrap/responsive.css.scss
+++ b/lib/assets/stylesheets/formtastic-plus-bootstrap/responsive.css.scss
@@ -5,6 +5,8 @@
  * have to have their own rows.
 */
 
+@import "bootstrap-responsive";
+
 // Phone to Portrait Tablet
 @media (max-width: 767px) {
   // this should only apply to formtastic forms


### PR DESCRIPTION
Fixes issue #14, bootstrap-responsive is only loaded when loading formtastic-plus-bootstrap/responsive
