### PR TITLE
Can now @import from subfolder

### DIFF
--- a/lib/assets/stylesheets/formtastic-plus-bootstrap/_all.scss
+++ b/lib/assets/stylesheets/formtastic-plus-bootstrap/_all.scss
@@ -5,17 +5,17 @@
 $labelWidth: (4 * $gridColumnWidth) !default;
 $inputWidth: (5 * $gridColumnWidth) !default;
 
-@import "mixins";
+@import "formtastic-plus-bootstrap/mixins";
 
 .formtastic {
-  @import "reset";
+  @import "formtastic-plus-bootstrap/reset";
 
-  @import "form";
-  @import "fieldset";
-  @import "actions";
-  @import "labels";
-  @import "hints";
-  @import "errors";
-  @import "inputs";
-  @import "disabled";
+  @import "formtastic-plus-bootstrap/form";
+  @import "formtastic-plus-bootstrap/fieldset";
+  @import "formtastic-plus-bootstrap/actions";
+  @import "formtastic-plus-bootstrap/labels";
+  @import "formtastic-plus-bootstrap/hints";
+  @import "formtastic-plus-bootstrap/errors";
+  @import "formtastic-plus-bootstrap/inputs";
+  @import "formtastic-plus-bootstrap/disabled";
 }

--- a/lib/assets/stylesheets/formtastic-plus-bootstrap/_inputs.scss
+++ b/lib/assets/stylesheets/formtastic-plus-bootstrap/_inputs.scss
@@ -9,15 +9,15 @@ fieldset.inputs {
       margin: (0.5 * $baseLineHeight) 0 $baseLineHeight 0;
       @include clearfix();
 
-      @import "inputs/stringish";
-      @import "inputs/range";
-      @import "inputs/text";
-      @import "inputs/boolean";
-      @import "inputs/check_boxes";
-      @import "inputs/radio";
-      @import "inputs/select";
-      @import "inputs/file";
-      @import "inputs/datetime";
+      @import "formtastic-plus-bootstrap/inputs/stringish";
+      @import "formtastic-plus-bootstrap/inputs/range";
+      @import "formtastic-plus-bootstrap/inputs/text";
+      @import "formtastic-plus-bootstrap/inputs/boolean";
+      @import "formtastic-plus-bootstrap/inputs/check_boxes";
+      @import "formtastic-plus-bootstrap/inputs/radio";
+      @import "formtastic-plus-bootstrap/inputs/select";
+      @import "formtastic-plus-bootstrap/inputs/file";
+      @import "formtastic-plus-bootstrap/inputs/datetime";
 
       .input-mini    { width: 1   * $gridColumnWidth !important; }
       .input-small   { width: 1.5 * $gridColumnWidth !important; }


### PR DESCRIPTION
Bootstrap itself did this same change to fix load path issues with SASS
compiler via PR: https://github.com/thomas-mcdonald/bootstrap-sass/pull/258/files

[ActiveAdmin](https://github.com/reverbhq/active_admin/tree/switch-to-bootstrap) is migrating to this and we were unable to include this CSS into a print stylesheet in a subfolder.

`app/stylesheets/active_admin/print.css.scss`

``` sass
@import "formtastic-plus-bootstrap";
```

This would fail b/c when pulling this in all of the mixins inside the `formtastic-plus-bootstrap` gem could not be located.  Importing the main file from a SASS file in the root of `app/stylesheets` worked fine.
